### PR TITLE
Fix EC2Instance Display format

### DIFF
--- a/src/aws/ec2-instance.rs
+++ b/src/aws/ec2-instance.rs
@@ -75,7 +75,7 @@ impl EC2Instance {
 
 impl fmt::Display for EC2Instance {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} {} {}", self.id, self.get_health(), self.get_name(),)
+        write!(f, "{} {} {}", self.id, self.get_health(), self.get_name(),)
     }
 }
 


### PR DESCRIPTION
## Summary
- format EC2 instance IDs without debug quotes in Display

## Testing
- `cargo test` *(fails: failed to download crates)*