### PR TITLE
Extract SDK setup function

### DIFF
--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -2,3 +2,5 @@
 pub(crate) mod ec2_instance;
 #[path = "ec2-instances.rs"]
 pub(crate) mod ec2_instances;
+#[path = "sdk_config.rs"]
+pub(crate) mod sdk_config;

--- a/src/aws/sdk_config.rs
+++ b/src/aws/sdk_config.rs
@@ -1,0 +1,22 @@
+use aws_config::meta::region::RegionProviderChain;
+use aws_config::{BehaviorVersion, Region, SdkConfig};
+
+pub async fn setup_sdk(region: &Option<String>, profile: &Option<String>) -> SdkConfig {
+    let region_provider = RegionProviderChain::first_try(region.clone().map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("eu-west-1"));
+    match &profile {
+        Some(profile_string) => {
+            aws_config::defaults(BehaviorVersion::latest())
+                .profile_name(profile_string)
+                .load()
+                .await
+        }
+        None => {
+            aws_config::defaults(BehaviorVersion::latest())
+                .region(region_provider)
+                .load()
+                .await
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,8 @@ use clap::Parser;
 mod aws;
 mod ui;
 use aws::ec2_instances::EC2InstanceCollection;
+use aws::sdk_config::setup_sdk;
 use ui::run_ui;
-
-use aws_config::meta::region::RegionProviderChain;
-use aws_config::{BehaviorVersion, Region, SdkConfig};
 
 #[derive(Debug, Parser)]
 struct Opt {
@@ -27,24 +25,4 @@ async fn main() -> Result<(), ()> {
 
     run_ui(instances, region.clone(), profile.clone());
     Ok(())
-}
-
-async fn setup_sdk(region: &Option<String>, profile: &Option<String>) -> SdkConfig {
-    let region_provider = RegionProviderChain::first_try(region.clone().map(Region::new))
-        .or_default_provider()
-        .or_else(Region::new("eu-west-1"));
-    match &profile {
-        Some(profile_string) => {
-            aws_config::defaults(BehaviorVersion::latest())
-                .profile_name(profile_string)
-                .load()
-                .await
-        }
-        None => {
-            aws_config::defaults(BehaviorVersion::latest())
-                .region(region_provider)
-                .load()
-                .await
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- move SDK setup logic from main to `aws::sdk_config`

## Testing
- `cargo test --offline` *(fails: no matching package named `arboard` found)*